### PR TITLE
Fixes the timeout problem when there are a lot of images to retrieve …

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "gatsby-node-helpers": "^0.3.0",
+    "lodash": "^4.17.15",
     "mysql": "^2.16.0",
     "pluralize": "^7.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2619,7 +2619,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.4:
+lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==


### PR DESCRIPTION
…by downloading images in batches of 3

If you have for example 700 images to download, all the requests were made at the same time to the server. As the server cannot answer all these requests at the same time, it puts the last requests on hold. As a result, these queued requests would fall in timeout. Chaining requests solves this problem.

You can easily change the batch size editing BATCH_SIZE const. A batch of 10 worked for me. See [this link](https://stackoverflow.com/questions/985431/max-parallel-http-connections-in-a-browser)  if you want to get an idea of the number to set as default. This constant could be added in the plugin's configuration variables if you think it could be useful.