### PR TITLE
fix exception during error reporting

### DIFF
--- a/src/create-mysql-nodes.js
+++ b/src/create-mysql-nodes.js
@@ -84,7 +84,11 @@ async function createMysqlNode(
             cache
           });
         } catch (e) {
-          reporter.error(`Error when getting image ${node[field]}`, e);
+          if (typeof e === 'string') {
+            reporter.error(`Error when getting image ${node[field]}: ${e.toString()}`);
+          } else {
+            reporter.error(`Error when getting image ${node[field]}`, e);
+          }
         }
       })
   );


### PR DESCRIPTION
- createRemoteFileNode will reject with a string
- therefore the call to reporter.error will fail
  as it expects an error object